### PR TITLE
Enabled utf-8 Encoding

### DIFF
--- a/snake_game.py
+++ b/snake_game.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*- 
 import curses
 from random import randint
 


### PR DESCRIPTION
The standard library only uses ASCII characters for identifiers, a convention that any portable code should follow. To display all non-ASCII characters properly, Editor must recognize that the file is UTF-8.

Python 2 uses ASCII as the default encoding for source files, which means we must specify another encoding at the top of the file to use non-ASCII unicode characters in literals.